### PR TITLE
fixes and optimization

### DIFF
--- a/src/cmdline.h
+++ b/src/cmdline.h
@@ -121,6 +121,7 @@ public:
    void ReadCommandLine(int argc, char * argv[]);     // Read and interpret command line
    int  SymbolChange(char const * oldname, char const ** newname, int symtype); // Check if symbol has to be changed
    int  SymbolIsInList(char const * name);   // Check if symbol is in SymbolList
+   int  SymbolBinSearch(char const * name, int nsym, int * found);
    int  SymbolChangesRequested();            // Any kind of symbol change requested on command line
    void ReportStatistics();                  // Report statistics about name changes etc.
    void CountDebugRemoved();                 // Increment CountDebugSectionsRemoved
@@ -167,7 +168,8 @@ protected:
    CArrayBuf<CFileBuffer> ResponseFiles;     // Array of up to 10 response file buffers
    int NumBuffers;                           // Number of response file buffers
    int SymbolChangeEntries;                  // Number of entries in SymbolList, except library entries
-   CMemoryBuffer SymbolList;                 // List of symbol names to change. Contains entries of type SSymbolChange
+   CMemoryBuffer SymbolList;                 // List of symbol names to change. Contains entries of type SSymbolChange. Kept in sorted order
+   CMemoryBuffer PrefixSuffixList;           // List of prefix/suffix to change. Contains entries of type SSymbolChange
    CMemoryBuffer MemberNames;                // Buffer containing truncated member names
    uint32 MemberNamesAllocated;              // Size of buffer in MemberNames
    uint32 CurrentSymbol;                     // Pointer into SymbolList

--- a/src/coff.cpp
+++ b/src/coff.cpp
@@ -666,8 +666,7 @@ void CCOFF::PublicNames(CMemoryBuffer * Strings, CSList<SStringEntry> * Index, i
       }
 
       // Search for public symbol
-      if ((Symtab.p->s.SectionNumber > 0 && Symtab.p->s.StorageClass == COFF_CLASS_EXTERNAL) 
-      || Symtab.p->s.StorageClass == COFF_CLASS_ALIAS) {
+      if (Symtab.p->s.SectionNumber > 0 && Symtab.p->s.StorageClass == COFF_CLASS_EXTERNAL) {
          // Public symbol found
          SStringEntry se;
          se.Member = m;

--- a/src/containers.cpp
+++ b/src/containers.cpp
@@ -157,15 +157,18 @@ uint32 CMemoryBuffer::GetLastIndex() {
     return NumEntries - 1;
 }
 
-void CMemoryBuffer::Align(uint32 a) {
-    // Align next entry to address divisible by a
-    uint32 NewOffset = (DataSize + a - 1) / a * a;
-    if (NewOffset > BufferSize) {
+void CMemoryBuffer::SetDataSize(uint32 size) {
+    if (size > BufferSize) {
         // Allocate more space
-        SetSize (NewOffset + 2048);
+        SetSize(size + 2048);
     }
     // Set DataSize to after alignment space
-    DataSize = NewOffset;
+    DataSize = size;
+}
+
+void CMemoryBuffer::Align(uint32 a) {
+    // Align next entry to address divisible by a
+    SetDataSize((DataSize + a - 1) / a * a);
 }
 
 // Members of class CFileBuffer

--- a/src/containers.h
+++ b/src/containers.h
@@ -93,6 +93,7 @@ public:
    CMemoryBuffer();                              // Constructor
    ~CMemoryBuffer();                             // Destructor
    void SetSize(uint32 size);                    // Allocate buffer of specified size
+   void SetDataSize(uint32 size);                // Claim space as a data
    uint32 GetDataSize()  {return DataSize;};     // File data size
    uint32 GetBufferSize(){return BufferSize;};   // Buffer size
    uint32 GetNumEntries(){return NumEntries;};   // Get number of entries

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -234,7 +234,7 @@ void CErrorReporter::submit(int ErrorNumber, int extra) {
    // ErrorTexts[ErrorNumber] must contain %i where extra is to be inserted
    char text[MAX_ERROR_TEXT_LENGTH];
    SErrorText * err = FindError(ErrorNumber);
-   sprintf(text, err->Text, extra);
+   snprintf(text, MAX_ERROR_TEXT_LENGTH, err->Text, extra);
    HandleError(err, text);
 }
 
@@ -243,7 +243,7 @@ void CErrorReporter::submit(int ErrorNumber, int extra1, int extra2) {
    // ErrorTexts[ErrorNumber] must contain two %i fields where extra numbers are to be inserted
    char text[MAX_ERROR_TEXT_LENGTH];
    SErrorText * err = FindError(ErrorNumber);
-   sprintf(text, err->Text, extra1, extra2);
+   snprintf(text, MAX_ERROR_TEXT_LENGTH, err->Text, extra1, extra2);
    HandleError(err, text);
 }
 
@@ -252,8 +252,7 @@ void CErrorReporter::submit(int ErrorNumber, char const * extra) {
    // ErrorTexts[ErrorNumber] must contain %s where extra is to be inserted
    char text[MAX_ERROR_TEXT_LENGTH];
    SErrorText * err = FindError(ErrorNumber);
-   strcpy (text, err->Text);
-   strncat( text, extra, MAX_ERROR_TEXT_LENGTH/2);
+   snprintf(text, MAX_ERROR_TEXT_LENGTH, err->Text, extra);
    HandleError(err, text);
 }
 
@@ -263,7 +262,7 @@ void CErrorReporter::submit(int ErrorNumber, char const * extra1, char const * e
    char text[MAX_ERROR_TEXT_LENGTH];
    if (extra1 == 0) extra1 = "???"; if (extra2 == 0) extra2 = "???";
    SErrorText * err = FindError(ErrorNumber);
-   sprintf(text, err->Text, extra1, extra2);
+   snprintf(text, MAX_ERROR_TEXT_LENGTH, err->Text, extra1, extra2);
    HandleError(err, text);
 }
 
@@ -273,7 +272,7 @@ void CErrorReporter::submit(int ErrorNumber, int extra1, char const * extra2) {
    char text[MAX_ERROR_TEXT_LENGTH];
    if (extra2 == 0) extra2 = "???";
    SErrorText * err = FindError(ErrorNumber);
-   sprintf(text, err->Text, extra1, extra2);
+   snprintf(text, MAX_ERROR_TEXT_LENGTH, err->Text, extra1, extra2);
    HandleError(err, text);
 }
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1567,23 +1567,21 @@ void CLibrary::SortStringTable() {
     SStringEntry * Table = &StringEntries[0];
     // String pointers
     char * s1, * s2;
-    // Temporary record for swapping
-    SStringEntry temp;
 
-    // Simple Bubble sort:
-    int32 i, j;
-    for (i = 0; i < n; i++) {
-        for (j = 0; j < n - i - 1; j++) {
-            s1 = StringBuffer.Buf() + Table[j].String;
-            s2 = StringBuffer.Buf() + Table[j+1].String;
-            if (strcmp(s1, s2) > 0) {
-                // Swap records
-                temp = Table[j];
-                Table[j] = Table[j+1];
-                Table[j+1] = temp;
+    // Simple Shell sort with Sedgewick gaps:
+    int32 i, j, k, gap;
+    for (k = 15; k >= 0; k--) {
+        gap = (1 << 2 * k) | (3 << k >> 1) | 1;  // Sedgewick gap grants O(N^4/3) 
+        for (i = gap; i < n; i++) {
+            SStringEntry key = Table[i];
+            char * strkey = StringBuffer.Buf() + key.String;
+            for (j = i - gap; j >= 0 && strcmp(strkey, StringBuffer.Buf() + Table[j].String) < 0; j -= gap) {
+                Table[j + gap] = Table[j];
             }
+            Table[j + gap] = key;
         }
     }
+
     // Now StringEntries has been sorted. Reorder StringBuffer to the sort order.
     CMemoryBuffer SortedStringBuffer;    // Temporary buffer for strings in sort order
     for (i = 0; i < n; i++) {

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -2085,7 +2085,7 @@ const char * CLibrary::GetModuleName(uint32 Index) {
                 // Long name in longnames record
                 uint32 NameIndex = atoi(name+1);
                 if (NameIndex < LongNamesSize) {
-                    return Buf() + LongNames + NameIndex;
+                    return LongNamesBuffer.Buf() + NameIndex;
                 }
                 else {
                     return "?";

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1382,9 +1382,11 @@ char * CLibrary::StripMemberName(char * name) {
             p1 = name + i + 1; break;
         }
     }
+    len -= i + 1;
+
     // move to begin of buffer
     if (p1 > name) {
-        strcpy(name, p1);
+        memmove(name, p1, len + 1);
     }
         
     // Get file type
@@ -1409,7 +1411,6 @@ char * CLibrary::StripMemberName(char * name) {
     }
 
     // find extension
-    len = (int)strlen(name);
     for (nlen = len-1; nlen >= 0; nlen--) {
         if (name[nlen] == '.') {
             break;
@@ -1417,7 +1418,6 @@ char * CLibrary::StripMemberName(char * name) {
     }
 
     // Remove any spaces or other illegal characters
-    len = (int)strlen(name);
     for (i = 0; i < nlen; i++) {
         if ((uint8)name[i] <= 0x20 || name[i] == '.') name[i] = '_';
     }

--- a/src/mac2mac.cpp
+++ b/src/mac2mac.cpp
@@ -136,6 +136,9 @@ void CMAC2MAC<MACSTRUCTURES>::MakeSymbolTable() {
    }
 
    // Put everything into symbol table and string table
+   if (this->SymTabNumber) {
+      NewStringTable.SetDataSize(1); // First record must indicate empty string (see nlist.n_un in Mach-O File Format Reference)
+   }
    for (NewScope = 0; NewScope < 3; NewScope++) {
       NewSymbols[NewScope].SortList();  // Sort each list alphabetically
       NewSymbols[NewScope].StoreList(&NewSymbolTable, &NewStringTable);

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -585,21 +585,20 @@ void MacSymbolTableBuilder<TMAC_nlist, MInt>::SortList() {
 
    MacSymbolRecord<TMAC_nlist> * p = (MacSymbolRecord<TMAC_nlist>*)Buf();     // Point to list
 
-   // Simple Bubble sort:
-   int i, j;  const char * s1, * s2;
-   MacSymbolRecord<TMAC_nlist> temp;
-   for (i = 0; i < (int)GetNumEntries(); i++) {
-      for (j = 0; j < (int)GetNumEntries() - i - 1; j++) {
-         s1 = StringBuffer.Buf() + p[j].Name;
-         s2 = StringBuffer.Buf() + p[j+1].Name;
-         if (strcmp(s1, s2) > 0) {
-            // Swap records
-            temp = p[j];
-            p[j] = p[j+1];
-            p[j+1] = temp;
+   // Simple Shell sort with Sedgewick gaps:
+   int i, j, k, gap, n = (int)GetNumEntries();
+   for (k = 15; k >= 0; k--) {
+      gap = (1 << 2 * k) | (3 << k >> 1) | 1;   // Sedgewick gap grants O(N^4/3) 
+      for (i = gap; i < n; i++) {
+         MacSymbolRecord<TMAC_nlist> key = p[i];
+         char * strkey = StringBuffer.Buf() + key.Name;
+         for (j = i - gap; j >= 0 && strcmp(strkey, StringBuffer.Buf() + p[j].Name) < 0; j -= gap) {
+            p[j + gap] = p[j];
          }
+         p[j + gap] = key;
       }
    }
+
    sorted = 1;
 }
 

--- a/src/maindef.h
+++ b/src/maindef.h
@@ -1,7 +1,7 @@
 /****************************  maindef.h   **********************************
 * Author:        Agner Fog
 * Date created:  2006-08-26
-* Last modified: 2018-08-15
+* Last modified: 2018-10-08
 * Project:       objconv
 * Module:        maindef.h
 * Description:
@@ -13,7 +13,7 @@
 #define MAINDEF_H
 
 // Program version
-#define OBJCONV_VERSION         2.50
+#define OBJCONV_VERSION         2.51
 
 
 // Integer type definitions with platform-independent sizes:

--- a/src/opcodes.cpp
+++ b/src/opcodes.cpp
@@ -1,13 +1,13 @@
 /****************************    opcodes.cpp    *******************************
 * Author:        Agner Fog
 * Date created:  2007-02-21 
-* Last modified: 2017-04-14
+* Last modified: 2018-10-08
 * Project:       objconv
 * Module:        opcodes.cpp
 * Description:
 * Definition of opcode maps used by disassembler
 *
-* Copyright 2007-2017 GNU General Public License http://www.gnu.org/licenses
+* Copyright 2007-2018 GNU General Public License http://www.gnu.org/licenses
 *****************************************************************************/
 
 
@@ -2351,7 +2351,7 @@ SOpcodeDef OpcodeMap58[3] = {
 //  name         instset prefix   format  dest.   source1 source2 source3 EVEX    MVEX    link    options
    {"movd",      0x7   , 0x11200, 0x12  , 0x1103, 0x3   , 0     , 0     , 0x00  , 0     , 0     , 0x2   },    // 0F 6E
    {"movd",      0x7   , 0x11200, 0x12  , 0x1103, 0x3   , 0     , 0     , 0x00  , 0     , 0     , 0x2   },    // 0F 6E
-   {"movq",      0x4000, 0x11200, 0x12  , 0x1404, 0x4   , 0     , 0     , 0x00  , 0     , 0     , 0x2   }};   // 0F 6E. Name varies: movd or movq, though the operand is 64 bits
+   {"movq",      0x4000, 0x11200, 0x12  , 0x1104, 0x4   , 0     , 0     , 0x00  , 0     , 0     , 0x2   }};   // 0F 6E. Name varies: movd or movq, though the operand is 64 bits
 
 // Tertiary opcode map for movd/movq. Opcode byte = 0F 7E
 // Indexed by prefix: none/66/F2/F3


### PR DESCRIPTION
Used objconv to rename ~20K symbols in a library with about 200K symbols. Have fixed few minor but obvious problems:
- nm show empty symbol, if it have forbidden zero index in Mach-O
- Error messages buffer overrun, bad formatting, and wrong symbol names output

Also, due to bubble sort and linear search, replacement took very long time (waited for hour w/o result)
For this reason, sorting changed to faster Shell sort, and binary search used on symbols list.