### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # the "invention" Makefile for `objconv' compilation with gcc
 
-SRCS = *.cpp
+SRCS = src/*.cpp
 OBJS = $(shell ls ${SRCS} | sed -e 's/\.cpp/.o/')
 
 DEBUG =


### PR DESCRIPTION
Fixes this error:

```bash
jordy@diomenia:~/code/objconv$ make
ls: cannot access '*.cpp': No such file or directory
g++  -o objconv 
g++: fatal error: no input files
compilation terminated.
make: *** [Makefile:20: all] Error 1
```